### PR TITLE
Fix hot_rank_active function so it doesn't fail on very old posts

### DIFF
--- a/migrations/2024-04-15-162000_fix_hot_rank_active_for_old_posts/down.sql
+++ b/migrations/2024-04-15-162000_fix_hot_rank_active_for_old_posts/down.sql
@@ -1,4 +1,7 @@
 -- Return the hot_rank_active function to its broken-for-old-posts version
+
+DROP FUNCTION hot_rank_active (score numeric, published timestamp with time zone, newest_comment_time timestamp with time zone);
+
 CREATE OR REPLACE FUNCTION hot_rank_active (score numeric, published timestamp with time zone, newest_comment_time timestamp with time zone)
     RETURNS float
     AS $$

--- a/migrations/2024-04-15-162000_fix_hot_rank_active_for_old_posts/down.sql
+++ b/migrations/2024-04-15-162000_fix_hot_rank_active_for_old_posts/down.sql
@@ -1,0 +1,38 @@
+-- Return the hot_rank_active function to its broken-for-old-posts version
+CREATE OR REPLACE FUNCTION hot_rank_active (score numeric, published timestamp with time zone, newest_comment_time timestamp with time zone)
+    RETURNS float
+    AS $$
+DECLARE
+    hours_diff_published numeric := EXTRACT(EPOCH FROM (now() - published)) / 3600;
+    adjusted_timestamp timestamp with time zone := (published
+                +
+                ('24:00:00'::interval
+                    *
+                    ( (1)::double precision
+                      -
+                      exp( (- 0.000012146493725346809)::double precision
+                            *
+                            date_part('epoch'::text,
+                                (GREATEST(newest_comment_time, published) - published)
+                            )
+                      )
+                    )
+                )
+              );
+    hours_diff numeric := EXTRACT(EPOCH FROM (now() - adjusted_timestamp)) / 3600;
+BEGIN
+    -- 24 * 7 = 168, so after a week, it will default to 0.
+    -- We use greatest(1,score+3) here and not greatest(2,score+2) to be fully true to the original
+    -- (and also Hexbear has no downvotes, so it doesn't matter for us anyway)
+    IF (hours_diff_published > 0 AND hours_diff_published < 168) THEN
+        RETURN log(greatest (1, score + 3)) / power((hours_diff + 2), 1.8);
+    ELSE
+        -- if the post is from the future, set hot score to 0. otherwise you can game the post to
+        -- always be on top even with only 1 vote by setting it to the future
+        RETURN 0.0;
+    END IF;
+END;
+$$
+LANGUAGE plpgsql
+IMMUTABLE PARALLEL SAFE;
+

--- a/migrations/2024-04-15-162000_fix_hot_rank_active_for_old_posts/up.sql
+++ b/migrations/2024-04-15-162000_fix_hot_rank_active_for_old_posts/up.sql
@@ -12,9 +12,12 @@ DECLARE
                       -
                       exp( (- 0.000012146493725346809)::double precision
                             *
-                            date_part('epoch'::text,
+                            LEAST(
                                 -- max value allowed here is 60 * 60 * 24 * 7 = 604800 (1 week in seconds)
-                                LEAST( (GREATEST(newest_comment_time, published) - published), 604800)
+                                date_part('epoch'::text,
+                                    (GREATEST(newest_comment_time, published) - published)
+                                ),
+                                604800
                             )
                       )
                     )

--- a/migrations/2024-04-15-162000_fix_hot_rank_active_for_old_posts/up.sql
+++ b/migrations/2024-04-15-162000_fix_hot_rank_active_for_old_posts/up.sql
@@ -1,4 +1,7 @@
 -- Fixing hot_rank_active to not break on ancient posts
+
+DROP FUNCTION hot_rank_active (score numeric, published timestamp with time zone, newest_comment_time timestamp with time zone);
+
 CREATE OR REPLACE FUNCTION hot_rank_active (score numeric, published timestamp with time zone, newest_comment_time timestamp with time zone)
     RETURNS float
     AS $$

--- a/migrations/2024-04-15-162000_fix_hot_rank_active_for_old_posts/up.sql
+++ b/migrations/2024-04-15-162000_fix_hot_rank_active_for_old_posts/up.sql
@@ -1,0 +1,39 @@
+-- Fixing hot_rank_active to not break on ancient posts
+CREATE OR REPLACE FUNCTION hot_rank_active (score numeric, published timestamp with time zone, newest_comment_time timestamp with time zone)
+    RETURNS float
+    AS $$
+DECLARE
+    hours_diff_published numeric := EXTRACT(EPOCH FROM (now() - published)) / 3600;
+    adjusted_timestamp timestamp with time zone := (published
+                +
+                ('24:00:00'::interval
+                    *
+                    ( (1)::double precision
+                      -
+                      exp( (- 0.000012146493725346809)::double precision
+                            *
+                            date_part('epoch'::text,
+                                -- max value allowed here is 60 * 60 * 24 * 7 = 604800 (1 week in seconds)
+                                LEAST( (GREATEST(newest_comment_time, published) - published), 604800)
+                            )
+                      )
+                    )
+                )
+              );
+    hours_diff numeric := EXTRACT(EPOCH FROM (now() - adjusted_timestamp)) / 3600;
+BEGIN
+    -- 24 * 7 = 168, so after a week, it will default to 0.
+    -- We use greatest(1,score+3) here and not greatest(2,score+2) to be fully true to the original
+    -- (and also Hexbear has no downvotes, so it doesn't matter for us anyway)
+    IF (hours_diff_published > 0 AND hours_diff_published < 168) THEN
+        RETURN log(greatest (1, score + 3)) / power((hours_diff + 2), 1.8);
+    ELSE
+        -- if the post is from the future, set hot score to 0. otherwise you can game the post to
+        -- always be on top even with only 1 vote by setting it to the future
+        RETURN 0.0;
+    END IF;
+END;
+$$
+LANGUAGE plpgsql
+IMMUTABLE PARALLEL SAFE;
+


### PR DESCRIPTION
The hot_rank_active function fails horribly when called on posts whose last comment was more than about 95 weeks after the post was published, due to an underflow error. This update fixes that issue by ensuring that the calculation uses instead the **lesser** of: 1 week in seconds, **_or_** the time between the post and its last comment.